### PR TITLE
FactoryBotとFakerの導入・実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -32,6 +32,8 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
   gem 'rspec-rails', '~> 4.0.0'
+  gem 'factory_bot_rails'
+  gem 'faker'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -84,6 +84,13 @@ GEM
       warden (~> 1.2.3)
     diff-lcs (1.4.4)
     erubi (1.10.0)
+    factory_bot (6.1.0)
+      activesupport (>= 5.0.0)
+    factory_bot_rails (6.1.0)
+      factory_bot (~> 6.1.0)
+      railties (>= 5.0.0)
+    faker (2.13.0)
+      i18n (>= 1.6, < 2)
     ffi (1.14.2)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -243,6 +250,8 @@ DEPENDENCIES
   byebug
   capybara (>= 2.15)
   devise
+  factory_bot_rails
+  faker
   jbuilder (~> 2.7)
   listen (>= 3.0.5, < 3.2)
   mysql2 (>= 0.5.3)

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    nickname              {Faker::Name.initials(number: 2)}
+    email                 {Faker::Internet.free_email}
+    password              {Faker::Internet.password(min_length: 6)}
+    password_confirmation {password}
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,17 +1,22 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
+  before do
+    @user = FactoryBot.build(:user) 
+    #各exampleでインスタンス作成を行うためあらかじめインスタンス変数に格納しておく
+  end
+  
   describe 'ユーザー新規登録' do
     it 'nicknameが空では登録できない' do
-      user = User.new(nickname: '', email: 'test@example', password: '000000', password_confirmation: '000000')
-      user.valid? #valid?はvalidateを実行し、空がなければtrueを返す
-      expect(user.errors.full_messages).to include("Nickname can't be blank")
+      @user.nickname = '' #nicknameが空のテストなのでnicknameに''を代入
+      @user.valid? #valid?はvalidateを実行し、空がなければtrueを返す
+      expect(@user.errors.full_messages).to include "Nickname can't be blank"
       #expect（検証結果）.to include(想定する結果) で検証結果が想定通りか判断する
     end
     it 'emailが空では登録できない' do
-      user = User.new(nickname: 'test', email: '', password: '000000', password_confirmation: '000000')
-      user.valid?
-      expect(user.errors.full_messages).to include("Email can't be blank")
+      @user.email = '' 
+      @user.valid?
+      expect(@user.errors.full_messages).to include "Email can't be blank"
       # includeをeqにする場合、配列として指定すればOK。
       # eq(["Email can't be blank"])とすれば、配列同士で照合可能
     end


### PR DESCRIPTION
*What*
インスタンス作成をFactory Botで効率化して、インスタンスのパラメーターをFakerでランダムに
*Why*
テストコードの効率化と登録データ重複によるエラーの回避のため、ランダムな値をFakerで導入した